### PR TITLE
Various fixes

### DIFF
--- a/KPM/cli/main.py
+++ b/KPM/cli/main.py
@@ -8,7 +8,16 @@ from importlib import import_module
 
 # Needed here or something else imports it with a different backend.
 import matplotlib
-matplotlib.use('TkAgg')
+import os
+if 'DISPLAY' in os.environ.keys():
+    if 'DISPLAY' == '':
+        _mpl_backend = 'Agg'
+    else:
+        _mpl_backend = 'TkAgg'
+else:
+    _mpl_backend = 'Agg'
+print(_mpl_backend)
+matplotlib.use(_mpl_backend)
 
 
 class CLIError(Exception):

--- a/KPM/cli/main.py
+++ b/KPM/cli/main.py
@@ -16,7 +16,6 @@ if 'DISPLAY' in os.environ.keys():
         _mpl_backend = 'TkAgg'
 else:
     _mpl_backend = 'Agg'
-print(_mpl_backend)
 matplotlib.use(_mpl_backend)
 
 

--- a/KPM/predict.py
+++ b/KPM/predict.py
@@ -146,9 +146,11 @@ class ModelPredictor:
             rmol = rmol_combined
             pmol = pmol_combined
             self.dH_arr = dH_combined
+        
+        n_reacs_adj = self.num_reacs if self.direction != 'both' else self.num_reacs*2
 
         # Calculate reaction difference fingerprint.
-        diffs = calc_diffs(self.num_reacs*2, self.descriptor_type, rmol, pmol, self.dH_arr,
+        diffs = calc_diffs(n_reacs_adj, self.descriptor_type, rmol, pmol, self.dH_arr,
                           self.morgan_radius, self.morgan_num_bits)
 
         return diffs

--- a/KPM/predict.py
+++ b/KPM/predict.py
@@ -111,7 +111,7 @@ class ModelPredictor:
         pmol = [Chem.MolFromSmiles(smi) for smi in psmi]
 
         # Load in enthalpies from file.
-        self.dH_arr = np.loadtxt(self.enthalpy)
+        self.dH_arr = np.loadtxt(self.enthalpy, ndmin=1)
 
         # Check lengths of array/lists.
         if len(self.dH_arr) != len(rmol) or len(self.dH_arr) != len(pmol):

--- a/KPM/train.py
+++ b/KPM/train.py
@@ -4,9 +4,6 @@ Used to create new KPM models and test their accuracy on
 given molecular datasets.
 '''
 
-import matplotlib
-matplotlib.use('TkAgg')
-
 from KPM.utils.data_funcs import load_dataset, extract_data, split_data
 from KPM.utils.data_funcs import normalise, un_normalise
 from KPM.utils.descriptors import calc_diffs
@@ -20,8 +17,6 @@ import numpy as np
 import os
 
 from numpy.typing import ArrayLike
-
-plt.ion()
 
 class ModelTrainer:
     '''Trains a neural network on a dataset of reactions.


### PR DESCRIPTION
Fixes to two previously discussed bugs (crash on single reaction prediction; crash on prediction with `--direction forward` or `--direction backward`), as well as a common crash I was having when running KPM with no available GUI (headless).

Full details for each fix are included in the individual commits. All have been tested with the examples and should be fully compatible with previous versions.